### PR TITLE
Fix code generation for tangential heading

### DIFF
--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -36,6 +36,12 @@
   let exportedCode = "";
 
   async function exportToCode() {
+    const headingTypeToFunctionName = {
+      constant: "setConstantHeadingInterpolation",
+      linear: "setLinearHeadingInterpolation",
+      tangential: "setTangentHeadingInterpolation",
+    };
+
     let file = `
     public class GeneratedPath {
       public GeneratedPath() {
@@ -62,7 +68,7 @@
                 }
                 new Point(${line.endPoint.x.toFixed(3)}, ${line.endPoint.y.toFixed(3)}, Point.CARTESIAN)
               )
-            ).set${titleCase(line.endPoint.heading)}HeadingInterpolation(${line.endPoint.heading === "constant" ? `Math.toRadians(${line.endPoint.degrees})` : line.endPoint.heading === "linear" ? `Math.toRadians(${line.endPoint.startDeg}), Math.toRadians(${line.endPoint.endDeg})` : ""})
+            ).${headingTypeToFunctionName[line.endPoint.heading]}(${line.endPoint.heading === "constant" ? `Math.toRadians(${line.endPoint.degrees})` : line.endPoint.heading === "linear" ? `Math.toRadians(${line.endPoint.startDeg}), Math.toRadians(${line.endPoint.endDeg})` : ""})
             ${line.endPoint.reverse ? ".setReversed(true)" : ""}
           `
           )


### PR DESCRIPTION
Previously, when exporting as code, it would generate `setTangentialHeadingInterpolation`, but the method is actually called [`setTangentHeadingInterpolation`](https://github.com/AnyiLin/Pedro-Pathing-Quickstart/blob/17f0ebaea5eed345defef806bd9787b8b71becf9/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/pathGeneration/PathBuilder.java#L141).